### PR TITLE
fix: pass history.values() to replaceFirstMessage

### DIFF
--- a/index.js
+++ b/index.js
@@ -40,7 +40,7 @@ client.on('messageCreate', async (message) => {
         if (!cmd.isBlockedPhrase) {
             const channel = message.channel;
             const history = await channel.messages.fetch({ limit: config.MessageFetchCount });
-            const sentMsg = await replaceFirstMessage(history, cmd.search, cmd.replacement, channel);
+            const sentMsg = await replaceFirstMessage(history.values(), cmd.search, cmd.replacement, channel);
             if (!sentMsg) {
                 channel.send(`${message.author} nobody said that, dumb ass`);
             } else {


### PR DESCRIPTION
Discord.js `Collection` iterates as `[id, Message]` pairs, not bare `Message` objects. `replaceFirstMessage` was receiving tuples so `msg.author` was always `undefined`, silently breaking `!s` in production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)